### PR TITLE
Add missing dependencies to bats.toml

### DIFF
--- a/bats.toml
+++ b/bats.toml
@@ -1,3 +1,8 @@
 [package]
 name = "zip"
 kind = "lib"
+
+[dependencies]
+"arith" = ""
+"array" = ""
+"result" = ""


### PR DESCRIPTION
Every #use now has a matching [dependencies] entry.