### PR TITLE
Fix parse_cd_entry next_offset calculation

### DIFF
--- a/src/lib.bats
+++ b/src/lib.bats
@@ -124,7 +124,7 @@ in
       uncompressed_size = uncompressed_size,
       local_header_offset = local_offset
     }
-  in @(entry, header_size) end
+  in @(entry, cd_offset + header_size) end
 end
 
 implement get_data_offset {l}{n} (data, data_len, local_offset) = let


### PR DESCRIPTION
## Summary
- `parse_cd_entry` returned `header_size` instead of `cd_offset + header_size` for the next entry offset
- This caused callers iterating central directory entries to jump to wrong offsets, making it impossible to find any entry that wasn't first in the CD
- Root cause of quire's EPUB import failing to find `META-INF/container.xml` (which is typically the 2nd CD entry after `mimetype`)

## Test plan
- [x] Verified via WASM disassembly that the compiled output stores only `header_size` without `cd_offset`
- [ ] Rebuild quire with fixed zip package and verify EPUB import works

🤖 Generated with [Claude Code](https://claude.com/claude-code)